### PR TITLE
Fix bookmarking / link sharing

### DIFF
--- a/v2/app/collegevine/App.jsx
+++ b/v2/app/collegevine/App.jsx
@@ -1161,7 +1161,7 @@ var Pivot_init = (Pivot.init = function(
   }
 
   function getPathWithState() {
-    return "?state=" + serializeFilters()
+    return `?state=${encodeURIComponent(serializeFilters())}`
   }
 
   function applyStateFromURL() {


### PR DESCRIPTION
JSON in URLs needs to be URI encoded to be detected by all tools, e.g. Slack, etc.

An interesting alternative is Bruno Jouhier’s (hello, here we meet again!) JSURL: https://github.com/Sage/jsurl

But that’s for another time.