### PR TITLE
APP-2313: Re-render templates when resetting items

### DIFF
--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -2477,6 +2477,7 @@ var PivotViewer = (Pivot.PivotViewer = function(
     }
 
     _activeItemsArr = newItems
+    newItems.forEach(updateTemplate)
 
     this.gridView()
     // force rearrange in case we are already in grid view, similar to old
@@ -2502,6 +2503,7 @@ var PivotViewer = (Pivot.PivotViewer = function(
     groups.forEach(group => {
       const { items } = group
       items.forEach(item => {
+        updateTemplate(item)
         _activeItemsArr.push(item)
       })
     })

--- a/v2/app/collegevine-hub/CVTemplate.js
+++ b/v2/app/collegevine-hub/CVTemplate.js
@@ -112,8 +112,15 @@ var templateRegex = /<\?(?:\??[^>]+)*\?>/g,
       outputString = outputChunks.join("")
 
       if (type === "html" || type === "fakehtml") {
-        // return an HTML element whose inner HTML is based on the provided template.
-        result.unsetHTML = outputChunks.join("")
+        // return an HTML element whose inner HTML is based on the provided template
+        result.unsetHTML = outputString
+
+        // APP-2313: When updating the data of an existing items, Pivot never
+        // re-renders the item based on the template. We explicitly do this here:
+        var isExistingItem = result === parent
+        if (isExistingItem) {
+          result.innerHTML = outputString
+        }
       } else if (type === "color") {
         // return a function that paints a colored rectangle.
         result = function(ctx, x, y, width, height) {

--- a/v2/app/collegevine-hub/CVTemplate.js
+++ b/v2/app/collegevine-hub/CVTemplate.js
@@ -116,8 +116,11 @@ var templateRegex = /<\?(?:\??[^>]+)*\?>/g,
         result.unsetHTML = outputString
 
         // APP-2313: When updating the data of an existing items, Pivot never
-        // re-renders the item based on the template. We explicitly do this here:
-        var isExistingItem = result === parent
+        // re-renders the item based on the template. We explicitly do this here
+        // by setting the `innerHTML` property of an existing item. Its `parent`
+        // is already present indicating it’s currently part of the document
+        // (DOM):
+        var isExistingItem = parent && result === parent
         if (isExistingItem) {
           result.innerHTML = outputString
         }

--- a/v2/app/collegevine-hub/CVTemplate.js
+++ b/v2/app/collegevine-hub/CVTemplate.js
@@ -1,0 +1,146 @@
+/*global Seadragon2, PivotNumber_format, makeElement*/
+
+var templateRegex = /<\?(?:\??[^>]+)*\?>/g,
+  makeTemplate = function(template, item, parent) {
+    var result,
+      inputString = template.template,
+      outputChunks = [],
+      outputString,
+      lastIndex = 0,
+      curIndex,
+      matchString,
+      matchLength,
+      evalResult,
+      type = template.type,
+      img,
+      doPaint
+
+    if (type === "html" || type === "fakehtml") {
+      // we'll be building an HTML element to represent the item.
+      // if the optional parent param was passed in, then strip out its innards
+      // and use it instead of making a new element.
+      if (parent) {
+        parent.innerHTML = ""
+        result = parent
+      } else {
+        result = makeElement("div", "pivot_item")
+      }
+      result.style.width = template.width + "px"
+      // if height is not specified, we assume it's square
+      result.style.height = (template.height || template.width) + "px"
+    }
+
+    if (type === "canvas") {
+      // canvas functions are built not per item, but once for all items.
+
+      // new Function()?! Why must we do this?
+      // Whoever builds the templates for this collection is allowed to specify functions
+      // to draw on canvas, since that can often out-perform HTML rendering and animation.
+      // They could be provided in a format like JSON, as strings. As noted elsewhere,
+      // the template author must already be a trusted entity because we're including
+      // arbitrary HTML from them, so they are allowed to run scripts on the client.
+      result =
+        typeof inputString === "function"
+          ? inputString
+          : new Function("ctx", "x", "y", "w", "h", "item", inputString)
+    } else {
+      while (!!(matchString = templateRegex.exec(inputString))) {
+        matchString = matchString[0]
+        curIndex = templateRegex.lastIndex // the index right after the current match
+        matchLength = matchString.length
+
+        // add any text that doesn't need modification
+        outputChunks.push(
+          inputString.substring(lastIndex, curIndex - matchLength)
+        )
+
+        // strip off the custom text delimiters
+        matchString = matchString.substring(2, matchLength - 2)
+
+        // modify the custom text
+        try {
+          // Oh no, it's a with statement! Why must we do this?
+          // Because of minification. We want developers to be able to easily write templates
+          // with easily readable properties like <?name?>, but we can't declare those as variables
+          // because they'll be minified.
+          // Any properly written template will NOT modify any external variables (although they can
+          // define temporary variables -- that's why we execute it inside a new scope), so the
+          // with statement should be relatively harmless.
+
+          // Oh no, it's an eval function! Why must we do this?
+          // First, it is not a security concern. Whoever supplies the HTML template already
+          // has an opportunity to run arbitrary script client-side by including <script> tags,
+          // onmouseover functions, etc., so the template provider must be trusted by the
+          // application regardless of how we do this template-filling step.
+          // Second, the template is provided as a string, which could be part of a JSON object
+          // or similar.
+          // Third, using eval (as opposed to inventing custom binding syntax) keeps the template verbosity
+          // to a minimum while giving the template writer the expressiveness to do interesting
+          // things with the data (beyond just outputting facets in their default representation).
+          // For instance, the reduce function on an array could be used to display all facet values
+          // in a variety of ways.
+          ;(function() {
+            with (item) {
+              evalResult = eval(matchString)
+            }
+          })()
+
+          // transform the result to a string, if it isn't already
+          // TODO this should take facet formatting rules into account
+          if (typeof evalResult === "number") {
+            evalResult = PivotNumber_format(evalResult)
+          } else if (evalResult instanceof Date) {
+            evalResult = evalResult.toLocaleString()
+          }
+
+          // push the string onto the result
+          outputChunks.push(evalResult)
+        } catch (e) {
+          // probably no big deal. it may have been trying to access a facet that's not set or something.
+          Seadragon2.Debug.warn(
+            "Error caught in filling template: " + e.message || e
+          )
+        }
+
+        lastIndex = curIndex
+      }
+
+      // pick up any text left after the last match
+      outputChunks.push(inputString.substring(lastIndex, inputString.length))
+
+      // put it all together in a string
+      outputString = outputChunks.join("")
+
+      if (type === "html" || type === "fakehtml") {
+        // return an HTML element whose inner HTML is based on the provided template.
+        result.unsetHTML = outputChunks.join("")
+      } else if (type === "color") {
+        // return a function that paints a colored rectangle.
+        result = function(ctx, x, y, width, height) {
+          ctx.fillStyle = outputString
+          ctx.fillRect(x, y, width, height)
+          return true
+        }
+      } else if (type === "img") {
+        // return a function that draws an image, specified by URL.
+        img = makeElement("img")
+        img.onload = function() {
+          doPaint = true
+        }
+        img.unsetSrc = outputString
+        result = function(ctx, x, y, width, height) {
+          var unsetSrc = img.unsetSrc
+          if (unsetSrc) {
+            img.src = img.unsetSrc
+            delete img.unsetSrc
+          }
+          if (doPaint) {
+            ctx.drawImage(img, x, y, width, height)
+          }
+          return doPaint
+        }
+      }
+    }
+
+    return result
+  }

--- a/v2/build/collegevine-hub/standalone.txt
+++ b/v2/build/collegevine-hub/standalone.txt
@@ -55,7 +55,7 @@ zoomcontainer/Viewer.js
 ../app/pivot/Date.js
 ../app/pivot/DatePicker.js
 ../app/pivot/Slider.js
-../app/pivot/Template.js
 ../app/pivot/Lzw.js
+../app/collegevine-hub/CVTemplate.js
 ../app/collegevine-hub/CVHubViewer.js
 ../app/collegevine-hub/CVHubApp.js


### PR DESCRIPTION
Fixes a bug where templates for existing items are not re-rendered.

---

@ChrisCoffey Checked out the test suite. There is good coverage, but none for Pivot yet. Will consider adding to it if/when we make bigger changes:

![image](https://user-images.githubusercontent.com/49583/76782511-a6e2ae00-67b0-11ea-959c-de00650ed57e.png)
