### PR TITLE
APP-6300: Seadragon: trigger focus and blur events on hover

### DIFF
--- a/Build/Scripts/seajax_v2.py
+++ b/Build/Scripts/seajax_v2.py
@@ -72,6 +72,7 @@ from sys import argv, path
 from file_helpers import *  # under %SDROOT%/Build/Scripts/
 from subprocess import call
 
+import os
 import shutil
 
 
@@ -86,7 +87,8 @@ def build_specific(target, type):
     # at the end is the _post wrapper for this type.
     files.append(PATH_POST_FILE % type)
 
-    shutil.rmtree(PATH_COMPILED_FILES)
+    if os.path.isdir(PATH_COMPILED_FILES):
+      shutil.rmtree(PATH_COMPILED_FILES)
     shutil.copytree(PATH_APP_FILES, PATH_COMPILED_FILES + "app")
     shutil.copytree(PATH_SRC_FILES, PATH_COMPILED_FILES + "src")
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ mouse interaction, so updates may be needed for newer browsers and touch
 interaction.
 
 # Prerequisites
-You must be on node version `10.15.3`
+
+You must be on Node.js version `10.15.3`
 # Setup
+
 First, install development tools using `npm install`.
 
 - 	**Windows:** To build all outputs, run

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ interaction.
 # Prerequisites
 
 You must be on Node.js version `10.15.3`
+
 # Setup
 
 First, install development tools using `npm install`.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ As a historical note, most of this code was written in 2010 and was targeted at
 mouse interaction, so updates may be needed for newer browsers and touch
 interaction.
 
-
+# Prerequisites
+You must be on node version `10.15.3`
 # Setup
-
 First, install development tools using `npm install`.
 
 - 	**Windows:** To build all outputs, run

--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -1160,6 +1160,8 @@ var PivotViewer = (Pivot.PivotViewer = function (
   function outlineItem(item, index, color, ctx, border, lineWidth) {
     var bounds, html
     if (item) {
+      self.trigger("itemFocus", item)
+
       bounds = item.source[index]
       if (templates[currentTemplateLevel].type !== "html") {
         // draw it on canvas

--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -1539,6 +1539,7 @@ var PivotViewer = (Pivot.PivotViewer = function (
         if (!anyItemHovered && oldHoveredItem) {
           self.trigger("itemBlur")
         }
+
         // prepare to draw outlines
         var lineWidth = viewport.deltaPointsFromPixels(
           new Seadragon2.Point(3, 0)
@@ -1574,6 +1575,7 @@ var PivotViewer = (Pivot.PivotViewer = function (
           }
           viewport.visibilityRatio = 1
         }
+
         // draw an outline for selected item
         outlineItem(
           selectedItem,

--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -1162,7 +1162,7 @@ var PivotViewer = (Pivot.PivotViewer = function (
     var bounds, html
 
     if (item) {
-      if (item != oldHoveredItem){
+      if (item !== oldHoveredItem){
         self.trigger("itemFocus", item)
         oldHoveredItem = item
       }
@@ -1442,7 +1442,6 @@ var PivotViewer = (Pivot.PivotViewer = function (
 
         centerItem = undefined
         zoomedIn = false
-        anyItemHovered = false
 
         // draw every item on the canvas
         for (j = activeItemsArr.length - 1; j >= 0; j--) {
@@ -1517,7 +1516,6 @@ var PivotViewer = (Pivot.PivotViewer = function (
                 ) {
                   hoveredItem = item
                   hoveredItemIndex = i
-                  anyItemHovered = true
 
                   if (!oldHoveredItem){
                     oldHoveredItem = hoveredItem
@@ -1536,7 +1534,7 @@ var PivotViewer = (Pivot.PivotViewer = function (
         }
 
         // if an item is selected, disable focus on hover
-        if (!anyItemHovered && oldHoveredItem){
+        if (hoveredItem && oldHoveredItem){
           self.trigger("itemBlur")
         }
         // prepare to draw outlines

--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -1442,6 +1442,7 @@ var PivotViewer = (Pivot.PivotViewer = function (
 
         centerItem = undefined
         zoomedIn = false
+        anyItemHovered = false
 
         // draw every item on the canvas
         for (j = activeItemsArr.length - 1; j >= 0; j--) {
@@ -1516,8 +1517,9 @@ var PivotViewer = (Pivot.PivotViewer = function (
                 ) {
                   hoveredItem = item
                   hoveredItemIndex = i
+                  anyItemHovered = true
 
-                  if (!oldHoveredItem) {
+                  if (!oldHoveredItem){
                     oldHoveredItem = hoveredItem
                   }
                 }
@@ -1534,7 +1536,7 @@ var PivotViewer = (Pivot.PivotViewer = function (
         }
 
         // if an item is selected, disable focus on hover
-        if (hoveredItem && oldHoveredItem){
+        if (!anyItemHovered && oldHoveredItem) {
           self.trigger("itemBlur")
         }
         // prepare to draw outlines

--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -1510,7 +1510,6 @@ var PivotViewer = (Pivot.PivotViewer = function (
                     ) || anythingChanged
                 }
 
-                // console.log(itemBounds.contains(contentMousePosition))
                 // check whether the mouse is over the current item
                 if (
                   lastMousePosition &&

--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -1517,7 +1517,7 @@ var PivotViewer = (Pivot.PivotViewer = function (
                   hoveredItem = item
                   hoveredItemIndex = i
 
-                  if (!oldHoveredItem){
+                  if (!oldHoveredItem) {
                     oldHoveredItem = hoveredItem
                   }
                 }


### PR DESCRIPTION
This PR implements `itemFocus` and `itemBlur` events for CV Hub canvas view.  Generally speaking, Seadragon is constantly iterating through all the items (schools in this context) in canvas.  For item in each iteration, it is checking if the user's mouse is over that item and outlining it if it is.  By this logic, for every iteration through the `n` items, there will be at most 1 item that is hovered, and `n - 1` items that are not hovered.  Therefore, we can fire a `itemFocus` event when we have an item that is being hovered over, but we need to wait until all the items have been iterated through to fire an `itemBlur` event because we need to ensure 0 items are currently focused.

I also introduced `oldItemHovered` so we can keep track of what item was hovered over on the previous iteration through the items.  That way, we can only fire an `itemFocus` event if a _new_ item came into focus.  Likewise, we can only fire an `itemBlur` event if we previously had an item focused.