### PR TITLE
APP-7093: Bugfix: only fire itemFocus event for hover, not select

### DIFF
--- a/v2/app/collegevine-hub/CVHubViewer.jsx
+++ b/v2/app/collegevine-hub/CVHubViewer.jsx
@@ -1162,11 +1162,6 @@ var PivotViewer = (Pivot.PivotViewer = function (
     var bounds, html
 
     if (item) {
-      if (item !== oldHoveredItem){
-        self.trigger("itemFocus", item)
-        oldHoveredItem = item
-      }
-
       bounds = item.source[index]
       if (templates[currentTemplateLevel].type !== "html") {
         // draw it on canvas
@@ -1554,6 +1549,11 @@ var PivotViewer = (Pivot.PivotViewer = function (
           domHoverBorder,
           lineWidth
         )
+
+        if (hoveredItem && hoveredItem !== oldHoveredItem){
+          self.trigger("itemFocus", hoveredItem)
+          oldHoveredItem = hoveredItem
+        }
 
         // show or hide the details pane as necessary
         if (centerItem && zoomedIn) {


### PR DESCRIPTION
Since the `itemFocus` event was firing from within `outlineItem`, it was getting fired for both hovered and selected items.  We only want it to be fired for hovered items, so this PR moves the event trigger to be outside of `outlineItem`